### PR TITLE
Push prefixes into OWLAPI from JsonLdParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # owlapi-jsonld
 
-[![Build Status](https://travis-ci.org/stain/owlapi-jsonld.svg)](https://travis-ci.org/stain/owl2jsonld)
+[![Build Status](https://travis-ci.org/stain/owlapi-jsonld.svg)](https://travis-ci.org/stain/owlapi-jsonld)
 
 
 [![doi:10.5281/zenodo.10561](https://zenodo.org/badge/doi/10.5281/zenodo.10561.png)](http://dx.doi.org/10.5281/zenodo.10561)


### PR DESCRIPTION
The prefixes are accessible via the RDFDataset sent to JsonLDTripleCallback.call. This pull request patches those through to the OWLAPI PrefixOntologyFormat code.

Also patched the build status URL to use the build status for this repository and not the owl2jsonld status.
